### PR TITLE
remove `better-setup-tools`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ Provides binaries in PyPi for Python 3.5+ for Windows, macOS and Linux.
 )
 
 if os.path.exists(os.path.join(os.path.abspath(os.path.dirname(__file__)), '.git')):
+    configuration['setup_requires'] = ['setuptools-git-versioning']
     configuration['version_config'] = {
         'version_format': '{tag}.dev{sha}',
         'starting_version': '0.1.0'

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ Provides binaries in PyPi for Python 3.5+ for Windows, macOS and Linux.
 )
 
 if os.path.exists(os.path.join(os.path.abspath(os.path.dirname(__file__)), '.git')):
-    configuration['setup_requires'] = ['better-setuptools-git-version']
     configuration['version_config'] = {
         'version_format': '{tag}.dev{sha}',
         'starting_version': '0.1.0'


### PR DESCRIPTION
Fixes python 3.10 support, because `better-setup-tools` is unmaintained.