### PR TITLE
Fix publish

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,6 +42,7 @@ jobs:
       id: download
       with:
         name: manylinux2_24_64
+        path: dist/
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
@@ -78,6 +79,7 @@ jobs:
       id: download
       with:
         name: manylinux2_24_32
+        path: dist/
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
@@ -120,6 +122,7 @@ jobs:
       id: download
       with:
         name: manylinux2_24_aarch64
+        path: dist/
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
@@ -156,6 +159,7 @@ jobs:
       id: download
       with:
         name: manylinux2_28_64
+        path: dist/
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
@@ -198,6 +202,7 @@ jobs:
       id: download
       with:
         name: manylinux2_28_aarch64
+        path: dist/
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
@@ -250,6 +255,7 @@ jobs:
       id: download
       with:
         name: mac_${{ matrix.arch }}_${{ matrix.python-version }}
+        path: dist/
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
@@ -319,6 +325,7 @@ jobs:
       id: download
       with:
         name: windows_${{ matrix.python-arch }}_${{ matrix.python-version }}
+        path: dist/
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
The GitHub publish step has changed and requires only the files to exist.  Update the download step to ensure the directories aren't copied.