### PR TITLE
Add permissions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,6 +8,8 @@ on:
   release:
     types: [ created ]
 
+permissions:
+  contents: read
 
 jobs:
 
@@ -36,6 +38,7 @@ jobs:
     needs: [ build_linux2_24_64 ]
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
     - uses: actions/download-artifact@v6
@@ -73,6 +76,7 @@ jobs:
     needs: [ build_linux2_24_32 ]
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
     - uses: actions/download-artifact@v6
@@ -116,6 +120,7 @@ jobs:
     needs: [ build_linux2_24_aarch64 ]
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
     - uses: actions/download-artifact@v6
@@ -153,6 +158,7 @@ jobs:
     needs: [ build_linux2_28_64 ]
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
     - uses: actions/download-artifact@v6
@@ -196,6 +202,7 @@ jobs:
     needs: [ build_linux2_28_aarch64 ]
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
     - uses: actions/download-artifact@v6
@@ -249,6 +256,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         arch: ['arm64', 'x86_64']
     permissions:
+      contents: read
       id-token: write
     steps:
     - uses: actions/download-artifact@v6
@@ -319,6 +327,7 @@ jobs:
           - python-version: '3.10'
             python-arch: 'arm64'
     permissions:
+      contents: read
       id-token: write
     steps:
     - uses: actions/download-artifact@v6


### PR DESCRIPTION
There are no explicit permissions for the GITHUB_TOKEN, which causes a CodeQL warning.  Add some in.