### PR TITLE
Add newer Linux builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -215,6 +215,126 @@ jobs:
       with:
         packages-dir: ${{ steps.download.outputs.download-path }}
 
+  build_linux2_34_64:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Execute the build
+        uses: docker://quay.io/pypa/manylinux_2_34_x86_64
+        with:
+          entrypoint: bash
+          args: /github/workspace/.github/workflows/build.sh
+      - name: Archive built wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: manylinux2_34_64
+          path: build/*.whl
+          if-no-files-found: error
+
+  publish_linux2_34_64:
+    if: github.event_name == 'release' && github.event.action == 'created'
+    needs: [ build_linux2_34_64 ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@v6
+      id: download
+      with:
+        name: manylinux2_34_64
+        path: dist/
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: ${{ steps.download.outputs.download-path }}
+
+  build_linux2_34_32:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Execute the build
+        uses: docker://quay.io/pypa/manylinux_2_34_i686
+        with:
+          entrypoint: linux32
+          args: bash /github/workspace/.github/workflows/build.sh
+      - name: Archive built wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: manylinux2_34_32
+          path: build/*.whl
+          if-no-files-found: error
+
+  publish_linux2_34_32:
+    if: github.event_name == 'release' && github.event.action == 'created'
+    needs: [ build_linux2_34_32 ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@v6
+      id: download
+      with:
+        name: manylinux2_34_32
+        path: dist/
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: ${{ steps.download.outputs.download-path }}
+
+  build_linux2_34_aarch64:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up emulation
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: aarch64
+
+      - name: Execute the build
+        uses: docker://quay.io/pypa/manylinux_2_34_aarch64
+        with:
+          entrypoint: bash
+          args: /github/workspace/.github/workflows/build.sh
+      - name: Archive built wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: manylinux2_34_aarch64
+          path: build/*.whl
+          if-no-files-found: error
+
+  publish_linux2_34_aarch64:
+    if: github.event_name == 'release' && github.event.action == 'created'
+    needs: [ build_linux2_34_aarch64 ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@v6
+      id: download
+      with:
+        name: manylinux2_34_aarch64
+        path: dist/
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: ${{ steps.download.outputs.download-path }}
+
   build_mac:
     runs-on: macos-latest
 


### PR DESCRIPTION
We were only building 3.10 and 3.11 for Linux due to the age of the images.  Add new builds with newer versions.